### PR TITLE
made commands more windows friendly, updates to latest version

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -1,40 +1,51 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
-
-KNATIVE_VERSION=${KNATIVE_VERSION:-0.19.0}
-KNATIVE_NET_KOURIER_VERSION=${KNATIVE_NET_KOURIER_VERSION:-0.19.1}
-
 set -u
 
+KNATIVE_VERSION=${KNATIVE_VERSION:-0.23.0}
+KNATIVE_NET=${KNATIVE_NET:-kourier}
+KNATIVE_NET_KOURIER_VERSION=${KNATIVE_NET_KOURIER_VERSION:-0.23.0}
+
+STARTTIME=$(date +%s)
+
+## INSTALL SERVING
+echo -e "\033[0;92m 🍿 Installing Knative Serving... \033[0m"
+
 n=0
+set +e
 until [ $n -ge 2 ]; do
-  kubectl apply -f https://github.com/knative/serving/releases/download/v$KNATIVE_VERSION/serving-crds.yaml && break
+  kubectl apply -f https://github.com/knative/serving/releases/download/v$KNATIVE_VERSION/serving-crds.yaml > /dev/null && break
   n=$[$n+1]
   sleep 5
 done
-kubectl wait --for=condition=Established --all crd
+set -e
+kubectl wait --for=condition=Established --all crd > /dev/null
 
 n=0
+set +e
 until [ $n -ge 2 ]; do
-  kubectl apply -f https://github.com/knative/serving/releases/download/v$KNATIVE_VERSION/serving-core.yaml && break
+  kubectl apply -f https://github.com/knative/serving/releases/download/v$KNATIVE_VERSION/serving-core.yaml > /dev/null && break
   n=$[$n+1]
   sleep 5
 done
-kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-serving
+set -e
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-serving > /dev/null
+
+
+## INSTALL KOURIER
+echo -e "\033[0;92m 🔌 Installing Knative Serving Networking Layer ${KNATIVE_NET}... \033[0m"
 
 n=0
 until [ $n -ge 2 ]; do
-  kubectl apply -f https://github.com/knative/net-kourier/releases/download/v$KNATIVE_NET_KOURIER_VERSION/kourier.yaml && break
+  kubectl apply -f https://github.com/knative-sandbox/net-kourier/releases/download/v$KNATIVE_NET_KOURIER_VERSION/kourier.yaml > /dev/null && break
   n=$[$n+1]
   sleep 5
 done
-kubectl wait --for=condition=Established --all crd
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n kourier-system > /dev/null
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-serving > /dev/null
 
-kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n kourier-system
-# deployment for net-kourier gets deployed to namespace knative-serving
-kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-serving
-
+# Configure Knative to use this ingress
 kubectl patch configmap/config-network \
   --namespace knative-serving \
   --type merge \
@@ -49,32 +60,16 @@ while [  -z $INGRESS_HOST ]; do
 done
 
 echo "The INGRESS_HOST is $INGRESS_HOST"
-kubectl patch configmap/config-network \
-  --namespace knative-serving \
-  --type merge \
-  --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
 KNATIVE_DOMAIN=$INGRESS_HOST.nip.io
 echo "The KNATIVE_DOMAIN $KNATIVE_DOMAIN"
 kubectl patch configmap -n knative-serving config-domain -p "{\"data\": {\"$KNATIVE_DOMAIN\": \"\"}}"
 
-cat <<EOF | kubectl apply -f -
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: hello
-spec:
-  template:
-    spec:
-      containers:
-        - image: gcr.io/knative-samples/helloworld-go
-          ports:
-            - containerPort: 8080
-          env:
-            - name: TARGET
-              value: "Knative"
-EOF
-kubectl wait ksvc hello --all --timeout=-1s --for=condition=Ready
-SERVICE_URL=$(kubectl get ksvc hello -o jsonpath='{.status.url}')
-echo "The Knative Service hello endpoint is $SERVICE_URL"
-curl $SERVICE_URL
+echo -e "🕹 Installing Knative Samples Apps... \033[0m"
+curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/03-serving-samples.sh | bash
+
+
+DURATION=$(($(date +%s) - $STARTTIME))
+
+echo -e "\033[0;92m 🚀 Knative installed with samples took: $(($DURATION / 60))m$(($DURATION % 60))s \033[0m"
+echo -e "\033[0;92m 🎉 Now have some fun with Serverless Apps \033[0m"


### PR DESCRIPTION
- for windows install point to minikube website
- remote `export` from cmd lines
- made cmd lines one line
- update knative, kourier, minikube, k8s to latest version
- made install verify more accurate 
- made the time to wait to scale to zero 10s

Closes #8 