### PR TITLE
doc: fix created broker name in verify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Some people call this **Serverless** 🎉 🌮 🔥
 
 - Verify broker
     ```bash
-    kubectl -n $NAMESPACE get broker default
+    kubectl -n $NAMESPACE get broker example-broker
     ```
 
 - Shoud print the address of the broker


### PR DESCRIPTION
According to the "Create a Broker" step, the created broker is called `example-broker`. By following the guide steps, this is is the result:
```
kubectl -n $NAMESPACE get broker default

Error from server (NotFound): brokers.eventing.knative.dev "default" not found
```

By following the guide after this PR, this is the result:
```
kubectl -n $NAMESPACE get broker example-broker
NAME             URL                                                                               AGE   READY   REASON
example-broker   http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker   23s   True    
``` 